### PR TITLE
Adds election date to tags archive; fixes election date typo on post

### DIFF
--- a/_layouts/tags.html
+++ b/_layouts/tags.html
@@ -32,6 +32,7 @@ layout: archive
         <h2 class="archive__subtitle">{{ tag[0] }}</h2>
         <div class="entries-{{ page.entries_layout | default: 'list' }}">
           {% for post in tag.last %}
+            <span class="page__meta">{{ post.election | date: "%B %-d, %Y"}}</span>
             {% include archive-single.html type=page.entries_layout %}
           {% endfor %}
         </div>

--- a/_posts/2018-06-12-Q1_RankedChoiceVoting.md
+++ b/_posts/2018-06-12-Q1_RankedChoiceVoting.md
@@ -1,7 +1,7 @@
 ---
 title:  "Question 1: Ranked-Choice Voting"
 excerpt: This approved measure enacts ranked-choice voting for some elections.
-election: 201-06-12
+election: 2018-06-12
 search: true
 header:
   overlay_image: /assets/img/2018_06/Question1_RankedChoice.jpg

--- a/_posts/2018-11-06-Q3_Transportation.md
+++ b/_posts/2018-11-06-Q3_Transportation.md
@@ -42,7 +42,7 @@ Principal: $106,000,000
 <br>Total cost: $135,150,000[^4]
 
 ### The money will be used to:
-* 80 million (plus $88 million in matching funds) for highways, secondary roads, and bridges[^4]
+* $80 million (plus $88 million in matching funds) for highways, secondary roads, and bridges[^4]
 * $20 million (plus $49 million in matching funds) for projects that “preserve public safety or otherwise demonstrate high economic value in terms of transportation” for things like  ports, railroads, airports, bicycle, and walking trails[^4]
 * $5 million (plus some matching funds) to fund a Department of Environmental Protection grant program for upgrading fish and wildlife habitats[^4]
 * $1 million for improving a pier at Maine Maritime Academy[^4]


### PR DESCRIPTION
Right now, the [tags page](https://maineballot.org/tags/) shows all ballot questions according to their respective tags. But the user can't tell in which election the ballot question appeared. This PR adds the election date to each ballot question listing.

The PR also fixes an election date typo.