### PR TITLE
Adds include for content appearing in multiple places

### DIFF
--- a/_includes/election-day.html
+++ b/_includes/election-day.html
@@ -1,0 +1,1 @@
+<h2 style="text-align: center;">The next election is <strong>{{ site.data.elections.current_election | date: "%B %-d, %Y"}}</strong></h2><br>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -5,7 +5,7 @@ layout: archive
 {{ content }}
 
 
-<h2 style="text-align: center;">The next election is <strong>{{ site.data.elections.current_election | date: "%B %-d, %Y"}}</strong></h2>
+{% include election-day.html %}
 
 <h3 class="archive__subtitle">{{ site.data.ui-text[site.locale].recent_posts | default: "Ballot questions" }}</h3>
 

--- a/vote.html
+++ b/vote.html
@@ -2,8 +2,9 @@
 layout: archive
 author_profile: false
 ---
-<h2 style="text-align: center;">The next election is <strong>{{ site.data.elections.current_election | date: "%B %-d, %Y"}}</strong></h2>
-<br>
+
+{% include election-day.html %}
+
 <h1>How to vote in Maine</h1>
 People over 18 who have a fixed principal residence in Maine can vote in state elections.  You must register to vote in the community you live in.
 <h2>Registering to vote</h2>


### PR DESCRIPTION
The "current election" content appears on at least two pages, and is hard-coded in each instance. Since this content is likely to change after an election happens, but before the next one is decided, it might make sense to create an include for it. With an include, the content can be managed in one place and automatically update every where else it occurs.