### PR TITLE
Changes election day tense, adds punctuation, adds subheading

### DIFF
--- a/_includes/election-day.html
+++ b/_includes/election-day.html
@@ -1,1 +1,1 @@
-<h2 style="text-align: center;">The next election is <strong>{{ site.data.elections.current_election | date: "%B %-d, %Y"}}</strong></h2><br>
+<h2 style="text-align: center;">The last election was <strong>{{ site.data.elections.current_election | date: "%B %-d, %Y"}}</strong></h2><br>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -18,5 +18,9 @@ layout: archive
 <!--{% include paginator.html %}-->
 
 <h3 class="archive__subtitle">{{ site.data.ui-text[site.locale].local_elections | default: "Local election information" }}</h3>
-We have links to local election websites and basic information about what's on the ballot for counties, cities, and towns. <a href="/local">Find information about your local election</a>
-<br><br>Curious about how this website got started? Listen to the story on the <a href="https://civictech.chat/2019/07/maine-ballot">Civic Tech Chat podcast</a>.
+
+<p>We have links to local election websites and basic information about what's on the ballot for counties, cities, and towns. <a href="/local">Find information about your local election</a>.</p>
+
+<h3 class="archive__subtitle">About this site</h3>
+
+<p>Curious about how this website got started? Listen to the story on the <a href="https://civictech.chat/2019/07/maine-ballot">Civic Tech Chat podcast</a>.</p>


### PR DESCRIPTION
- Changes tense of election date ("last election was...")
- Adds punctuation to "Find information about your local election."
- Adds subheading to homepage to separate local elections from civic tech chat podcast link