### PR TITLE
Adds _site back to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .jekyll-metadata
 .sass-cache
 _asset_bundler_cache
+_site
 codekit-config.json
 example/_site
 Gemfile.lock


### PR DESCRIPTION
We deployed `_site` to run a static deploy of its contents via Netlify, but we provisionally have successful builds in Netlify now, so I think we can add it back, pending a successful Netlify build and deploy.