### PR TITLE
Inline links -> bulleted list

### DIFF
--- a/_posts/2020-07-14-Q1_Internet.md
+++ b/_posts/2020-07-14-Q1_Internet.md
@@ -65,9 +65,9 @@ The primary arguments against this referendum are:
 Nobody has registered support or opposition to this bond.
 
 ## Further reading
-[Full text](https://legislature.maine.gov/legis/bills/bills_129th/chapters/PUBLIC673.asp)
-[Ballotpedia article](https://ballotpedia.org/Maine_Question_1,_High-Speed_Internet_Infrastructure_Bond_Issue_(July_2020))
-[ConnectMaine State of Maine Broadband Action Plan](https://www.maine.gov/connectme/sites/maine.gov.connectme/files/inline-files/State%20of%20Maine%20-%20Statewide%20Broadband%20Action%20Plan%202020_1.pdf)
+- [Full text](https://legislature.maine.gov/legis/bills/bills_129th/chapters/PUBLIC673.asp)
+- [Ballotpedia article](https://ballotpedia.org/Maine_Question_1,_High-Speed_Internet_Infrastructure_Bond_Issue_(July_2020))
+- [ConnectMaine State of Maine Broadband Action Plan](https://www.maine.gov/connectme/sites/maine.gov.connectme/files/inline-files/State%20of%20Maine%20-%20Statewide%20Broadband%20Action%20Plan%202020_1.pdf) (PDF)
 
 ## References
 [^1]: Maine State Legislature. [An Act To Authorize a General Fund Bond Issue for Infrastructure To Improve Transportation and Internet Connections](https://legislature.maine.gov/legis/bills/bills_129th/chapters/PUBLIC673.asp). Accessed June 3, 2020.

--- a/_posts/2020-07-14-Q2_Transportation.md
+++ b/_posts/2020-07-14-Q2_Transportation.md
@@ -60,8 +60,8 @@ The primary arguments against this referendum are:
 Nobody has registered support or opposition to this bond.
 
 ## Further reading
-[Full text](https://legislature.maine.gov/legis/bills/bills_129th/chapters/PUBLIC673.asp)
-[Ballotpedia article](https://ballotpedia.org/Maine_Question_2,_Transportation_Infrastructure_Bond_Issue_(July_2020))
+- [Full text](https://legislature.maine.gov/legis/bills/bills_129th/chapters/PUBLIC673.asp)
+- [Ballotpedia article](https://ballotpedia.org/Maine_Question_2,_Transportation_Infrastructure_Bond_Issue_(July_2020))
 
 ## References
 [^1]: Maine State Legislature. [An Act To Authorize a General Fund Bond Issue for Infrastructure To Improve Transportation and Internet Connections](https://legislature.maine.gov/legis/bills/bills_129th/chapters/PUBLIC673.asp). Accessed June 3, 2020.


### PR DESCRIPTION
I noticed the "further reading" links are inline. This is an issue for both posts. This PR adds an unordered list to fix this. I also added `(PDF)` for the one PDF document in further reading.

## Production
<img width="760" alt="Further reading with inline links for full text, ballotpedia article, connectmaine state of maine broadband action plan, all links are on one line" src="https://user-images.githubusercontent.com/15129890/84328334-8e2b2f80-ab36-11ea-9347-f546bd426455.png">

## This branch
<img width="609" alt="same links in previous image presented in unordered list" src="https://user-images.githubusercontent.com/15129890/84328420-bdda3780-ab36-11ea-81a7-1a60056fd135.png">

