### PR TITLE
[WIP] Abstracts in-page search to apply to other pages

### DIFF
--- a/_includes/candidates-data.html
+++ b/_includes/candidates-data.html
@@ -1,5 +1,9 @@
+
+{% include search-in-page.html %}
+
 <h2>Democratic Party</h2>
 <h3>Contested races</h3>
+
 <p>There are more than one candidate for these races, so you might need to do some research before making a choice.</p>
 <table>
     <thead>

--- a/_includes/local-election-data.html
+++ b/_includes/local-election-data.html
@@ -1,4 +1,4 @@
-<input id="town-search" type="text" placeholder="Search for town..." />
+{% include search-in-page.html %}
 
 <table>
     <thead>

--- a/_includes/search-in-page.html
+++ b/_includes/search-in-page.html
@@ -1,0 +1,60 @@
+<script src="http://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script>
+    (function($) {
+  function icontains(elem, text) {
+    return (elem.textContent || '')
+      .toLowerCase()
+      .indexOf((text || '').toLowerCase()) > -1;
+  }
+
+  $.expr.pseudos.icontains = $.expr.createPseudo(function(text) {
+    return function(elem) {
+      return icontains(elem, text);
+    };
+  })
+})(jQuery);
+
+$(document).ready(function() {
+  function sendSearchEvent(searchStr) {
+    window.dataLayer.push(
+      {'event': 'search-str-update', 'searchStr': searchStr }
+    );
+  }
+
+  // Only call sendSearchEvent once the user has stopped typing for
+  // at least SEARCH_EVENT_DEBOUNCE_INTERVAL milliseconds, and then
+  // only if the value has changed since the last time sendSearchEvent
+  // was called.
+  var SEARCH_EVENT_DEBOUNCE_INTERVAL = 1000;
+  var timeoutId;
+  var lastEvent = { value: null }
+  function debounceSendSearchEvent(searchStr) {
+    if (timeoutId) {
+      window.clearTimeout(timeoutId);
+    }
+    if (searchStr && searchStr !== lastEvent.value) {
+      timeoutId = window.setTimeout(function() {
+        lastEvent.value = searchStr;
+        sendSearchEvent(searchStr)
+      }, SEARCH_EVENT_DEBOUNCE_INTERVAL);
+    }
+  }
+
+  $('input#ballot-search').change(function() {
+    var search_str = $(this).val().toLowerCase();
+
+    if (search_str) {
+      $('td:nth-child({{ page.search_column }}):icontains(' + search_str + ')').parent().show()
+      $('td:nth-child({{ page.search_column }}):not(:icontains(' + search_str + '))').parent().hide()
+    } else {
+      $('tr').show()
+    }
+    debounceSendSearchEvent(search_str);
+  }).keyup(function() {
+    $(this).change();
+  })
+});
+
+</script>
+
+<input id="ballot-search" aria-label="Search the ballot" type="text" placeholder="Search for {{ page.search_for }}..." />

--- a/_pages/candidates.md
+++ b/_pages/candidates.md
@@ -4,6 +4,8 @@ title: "State & county candidates"
 author_profile: false
 datafile: candidates
 permalink: /candidates
+search_for: candidate
+search_column: 4
 ---
 Below is a list of candidates for state and county level offices.  Because this is a primary election, you must be registered with one of the parties to vote for candidates. Note: The parties are listed alphabetically and candidates are listed alphabetically by last name for each office.
 <br><br>

--- a/_pages/local.md
+++ b/_pages/local.md
@@ -5,6 +5,8 @@ author_profile: false
 datafile: local
 ballot_description: "What's on the July 2020 ballot"
 permalink: /local
+search_column: 2
+search_for: town
 ---
 
 This is a work in progress list of websites or contact information for county, city, and town elections in Maine. The information about what's on the local ballot is based on what we could find on the locality websites, but may not be complete because the websites aren't all up to date with information about the current election. If information about your locality isn't listed and you would like to provide us with the information, please send it to [maineballot@gmail.com](mailto:maineballot@gmail.com).


### PR DESCRIPTION
Fixes #113 

This is a work-in-progress solution to adding in-page search to the new candidates page. It needs work.

- The existing in-page search targets the `town-search` id. This abstracts the id to `ballot-search` to generalize
- Moves the global `js` file to an `html` include enclosed in `script` (enables page-level Liquid variable injection)
- Requires new front matter variables (`search_column`, `search_for`) in pages that include in-page search
  - The script targets a specific column for search query, which is column 2 in the ballot search, but column 4 in the candidate search; `search_column` assigns the column to search
  -  Placeholder text changes based on the `search_for` key
- The page is broken into several tables, and the search applies to all of them, but that may not be intuitive. User testing would be informative on placement.

**This solution is not performant. It works, but it must include the jquery library in the `_include` script for scope.**

The include script doesn't see the jquery library without explicit inclusion inline. I'm working on a solution, but welcome assistance from JS devs.
