### PR TITLE
Adds margin to blue box and heading

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -21,6 +21,10 @@
     margin-right: 0px !important;
 }
 
+.top-gap {
+    margin-top: 1.5em;
+}
+
 .text-white{
     color: #ffffff;
 }

--- a/vote.html
+++ b/vote.html
@@ -5,7 +5,7 @@ author_profile: false
 
 {% include election-day.html %}
 
-<h1>How to vote in Maine</h1>
+<h1 class="top-gap">How to vote in Maine</h1>
 People over 18 who have a fixed principal residence in Maine can vote in state elections.  You must register to vote in the community you live in.
 <h2>Registering to vote</h2>
 Maine has no deadline for registering in person at your town office or city hall.  You can also register to vote by mail up to 21 days before an election.<br>


### PR DESCRIPTION
The box and heading combination is a little compact now. This adds some margin to the `h1` on the `vote` page to give a little breathing room.

## Production
<img width="673" alt="Maine Ballot masthead with next election text and how to vote in maine just below" src="https://user-images.githubusercontent.com/15129890/94882866-fb343f00-041d-11eb-84f5-46f8036f8890.png">

## This PR
<img width="677" alt="Maine Ballot masthead with next election text and how to vote in maine just below" src="https://user-images.githubusercontent.com/15129890/94882942-39c9f980-041e-11eb-9efe-6509ce190cf6.png">
