### PR TITLE
Update election day status

### DIFF
--- a/_includes/election-day.html
+++ b/_includes/election-day.html
@@ -1,6 +1,6 @@
 <div class="medium-blue full-wide">
   <p class="text-center">
-    <span class="content-med-b text-white">The next Maine election is</span><br />
+    <span class="content-med-b text-white">The last Maine election was</span><br />
     <span class="content-lrg-b text-white">{{ site.data.elections.current_election | date: "%B %-d, %Y"}}</span><br/>
     <span class="content-sm-b text-white">General Election</span><br/>
   </p>


### PR DESCRIPTION
Changes tense for election include:

~~The next Maine election is November 3, 2020~~

The last Maine election was November 3, 2020