### PR TITLE
Adds front matter keys to archive pages to enable table search

### DIFF
--- a/_local-archive/local-2019-11.md
+++ b/_local-archive/local-2019-11.md
@@ -5,6 +5,8 @@ author_profile: false
 datafile: local-2019-11
 ballot_description: "What's on the November 2019 ballot"
 election: November 2019 Election
+search_for: town
+search_column: 2
 ---
 
 This is a list of websites or contact information for county, city, and town elections in Maine as of November 2019. The information about what's on the local ballot is based on what we could find on the locality websites, but may not be complete because the websites aren't all up to date with information about the current election.

--- a/_local-archive/local-2020-07.md
+++ b/_local-archive/local-2020-07.md
@@ -5,6 +5,8 @@ author_profile: false
 datafile: local-2020-07
 ballot_description: "What's on the July 2020 ballot"
 election: July 2020 Election
+search_for: town
+search_column: 2
 ---
 
 This is a list of websites or contact information for county, city, and town elections in Maine as of July 2020. The information about what's on the local ballot is based on what we could find on the locality websites, but may not be complete because the websites aren't all up to date with information about the current election.

--- a/_local-archive/local-2020-11.md
+++ b/_local-archive/local-2020-11.md
@@ -5,6 +5,8 @@ author_profile: false
 datafile: local-2020-11
 ballot_description: "What's on the November 2020 ballot"
 election: November 2020 Election
+search_for: town
+search_column: 2
 ---
 
 This is a list of websites or contact information for county, city, and town elections in Maine as of November 2020. The information about what's on the local ballot is based on what we could find on the locality websites, but may not be complete because the websites aren't all up to date with information about the current election.


### PR DESCRIPTION
In-page search wasn't working on archived pages because they lacked two front matter keys necessary for table search:
```
search_for: town
search_column: 2
```

This branch adds the front matter keys to archive `md` files to enable search.