### PR TITLE
Contributor year edit

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -4,7 +4,7 @@ author_profile: false
 ---
 <h1>Contributors</h1>
 
-<h2>2021</h2>
+<h2>2022</h2>
 Shannon McHarg
 <br>Chris Bridgham
 <br>Nathan Bernard


### PR DESCRIPTION
Noticed duplicate 2021s and assumed one should be 2022 

(we're all still stuck in 2020, after all)

<img width="295" alt="screenshot with 2021 listing contributors and 2021 listing contributors" src="https://user-images.githubusercontent.com/15129890/181122282-e35e8266-3327-48a2-8417-3ee447107474.png">
