### PR TITLE
Styles left border, tweaks padding, removes border from last item

### DIFF
--- a/_sass/minimal-mistakes/_ballotfill.scss
+++ b/_sass/minimal-mistakes/_ballotfill.scss
@@ -29,6 +29,11 @@
     margin-bottom: 0;
     padding-bottom: 2rem;
     padding-left: calc(calc((2.5rem/2) - .25rem)*2);
+
+    &:last-child {
+        border: none;
+        padding-left: 2.5rem;
+    }
 }
 
 li.ab-ballot-list-item {
@@ -65,4 +70,5 @@ li.ab-ballot-list-item {
     font-family: Source Sans Pro Web,Helvetica Neue,Helvetica,Roboto,Arial,sans-serif;
     font-weight: 700;
     margin: 0;
+    padding-top: 0.4rem;
 }

--- a/_sass/minimal-mistakes/_ballotfill.scss
+++ b/_sass/minimal-mistakes/_ballotfill.scss
@@ -31,6 +31,10 @@
     padding-left: calc(calc((2.5rem/2) - .25rem)*2);
 }
 
+li.ab-ballot-list-item {
+    margin-left: 0.3rem;
+}
+
 .ab-ballot-list-item::before {
     flex-direction: row;
     align-items: center;


### PR DESCRIPTION
This pull request:

- Aligns border to the center of list items
- Removes border from last item
- Bumps heading down slightly to align with ordered list item

## Preview screen shots

### Border alignment and heading padding

<img width="1377" alt="Screenshot showing process ordered list" src="https://github.com/OpenMaine/maineballot/assets/15129890/29f2906f-b751-4278-a58f-c5236d7494a0">

### Last item border removed

<img width="1364" alt="Screenshot showing last item of ordered list without a border" src="https://github.com/OpenMaine/maineballot/assets/15129890/bf0b13cc-b7d0-4188-b140-1356a76664e8">
