### PR TITLE
Typo and fix for color contrast issues for footnotes

### DIFF
--- a/_posts/2023-11-07-Q2_ForeignContributions.md
+++ b/_posts/2023-11-07-Q2_ForeignContributions.md
@@ -19,7 +19,7 @@ no_vote: I don't want to prevent foreign influence in elections for candidates a
 last_modified_at: 2023-10-07 T12:17:00-05:00
 ---
 ## The gist
-This citizen's initiative would prohibit foreign influcen in elections for candidates and ballot questions.
+This citizen's initiative would prohibit foreign influence in elections for candidates and ballot questions.
 
 ## Ballot question
 Do you want to ban foreign governments and entities that they own, control, or influence from making campaign contributions or financing communications for or against candidates or ballot questions?[^1]

--- a/_sass/minimal-mistakes/_utilities.scss
+++ b/_sass/minimal-mistakes/_utilities.scss
@@ -456,12 +456,12 @@ body:hover .visually-hidden button {
    ========================================================================== */
 
 .footnote {
-  color: mix(#fff, $gray, 25%);
+  /* color: mix(#fff, $gray, 25%); */
   text-decoration: none;
 }
 
 .footnotes {
-  color: mix(#fff, $gray, 25%);
+  /* color: mix(#fff, $gray, 25%); */
 
   ol,
   li,


### PR DESCRIPTION


This is a bug fix. 


## Summary

* https://www.maineballot.org/november%202023%20election/q2_foreigncontributions/ typo fix for "influence"
* removed footnote/footnotes (links and list of footnotes) color declaration to fix a color contrast issue.
