### PR TITLE
Update internal links trailing slash

### DIFF
--- a/src/components/footer.astro
+++ b/src/components/footer.astro
@@ -12,7 +12,7 @@ import { SITE_META } from '#utils/constants'
         > volunteers.
       </p>
       <p class="text-sm lg:text-base mb-4 text-neutral-600">
-        <a href="/about" class="underline">Learn more about the project here.</a>
+        <a href="/about/" class="underline">Learn more about the project here.</a>
       </p>
     </div>
     <div>

--- a/src/data/ballot-questions/july-2020/Q1_Internet.mdx
+++ b/src/data/ballot-questions/july-2020/Q1_Internet.mdx
@@ -42,7 +42,7 @@ Passing this question would allow the state to borrow $15 million, matched by $3
 
 Passing this question would allow the State of Maine to borrow $15 million for the ConnectME Authority, a public organization responsible for promoting high-speed internet usage in unserved and underserved areas of Maine.[^2]
 
-This is a **bond issue** -- if voters approve the bond, it means that the State of Maine is allowed to borrow money for the project described in the ballot question and has to pay it back over 10 years.[^3] [Learn more about how bonds work](/bonds).
+This is a **bond issue** -- if voters approve the bond, it means that the State of Maine is allowed to borrow money for the project described in the ballot question and has to pay it back over 10 years.[^3] [Learn more about how bonds work](/bonds/).
 
 ## Follow the money
 

--- a/src/data/ballot-questions/july-2020/Q2_Transportation.mdx
+++ b/src/data/ballot-questions/july-2020/Q2_Transportation.mdx
@@ -41,7 +41,7 @@ Passing this question would allow the state to borrow $105 million, matched by $
 
 Passing this question would allow the State of Maine to borrow $105 million for a variety of infrastructure improvements, including roads, bridges, railroads, airports, transit and ports.[^2] The bulk of the money will go towards high priority highways and bridges.
 
-This is a **bond issue** -- if voters approve the bond, it means that the State of Maine is allowed to borrow money for the project described in the ballot question and has to pay it back over 10 years.[^3] [Learn more about how bonds work](/bonds).
+This is a **bond issue** -- if voters approve the bond, it means that the State of Maine is allowed to borrow money for the project described in the ballot question and has to pay it back over 10 years.[^3] [Learn more about how bonds work](/bonds/).
 
 ## Follow the money
 

--- a/src/data/ballot-questions/november-2018/Q2_Wastewater.mdx
+++ b/src/data/ballot-questions/november-2018/Q2_Wastewater.mdx
@@ -41,7 +41,7 @@ Passing this question would allow the state to borrow $30 million to improve wat
 
 Passing this question would provide funds to towns, wastewater facilities, and homeowners, primarily in areas that affect the coast and shell fishing areas to fix broken wastewater disposal systems.
 
-This is a **bond issue** -- if voters approve the bond, it means that the State of Maine is allowed to borrow money for the project described in the ballot question and has to pay it back over 10 years.[^3] [Learn more about how bonds work](/bonds).
+This is a **bond issue** -- if voters approve the bond, it means that the State of Maine is allowed to borrow money for the project described in the ballot question and has to pay it back over 10 years.[^3] [Learn more about how bonds work](/bonds/).
 
 ## Follow the money
 

--- a/src/data/ballot-questions/november-2018/Q3_Transportation.mdx
+++ b/src/data/ballot-questions/november-2018/Q3_Transportation.mdx
@@ -41,7 +41,7 @@ Passing this question would allow the state to borrow $106 million for transport
 
 Passing this question would allow the State of Maine to borrow $106 million for a variety of infrastructure improvements, including highways, bridges, ports, railroads, airports, bicycle, and walking trails.[^3]
 
-This is a **bond issue** -- if voters approve the bond, it means that the State of Maine is allowed to borrow money for the project described in the ballot question and has to pay it back over 10 years.[^3] [Learn more about how bonds work](/bonds).
+This is a **bond issue** -- if voters approve the bond, it means that the State of Maine is allowed to borrow money for the project described in the ballot question and has to pay it back over 10 years.[^3] [Learn more about how bonds work](/bonds/).
 
 ## Follow the money
 

--- a/src/data/ballot-questions/november-2018/Q4_University.mdx
+++ b/src/data/ballot-questions/november-2018/Q4_University.mdx
@@ -41,7 +41,7 @@ Approving this question would allow the state to borrow $49 million, matched by 
 
 If this question is approved, it will allow the state to borrow up to $49 million to improve dormitories, laboratories, and classrooms for STEM (science, technology, engineering, and math) programs, nursing, and childcare programs, career centers, and facilities for first-generation and non-traditional students at University of Maine system campuses. This money will be matched by private and public funds that don’t have to be paid back.[^4]
 
-This is a **bond issue** -- if voters approve the bond, it means that the State of Maine is allowed to borrow money for the project described in the ballot question and has to pay it back over 10 years.[^3] [Learn more about how bonds work](/bonds).
+This is a **bond issue** -- if voters approve the bond, it means that the State of Maine is allowed to borrow money for the project described in the ballot question and has to pay it back over 10 years.[^3] [Learn more about how bonds work](/bonds/).
 
 ## Follow the money
 

--- a/src/data/ballot-questions/november-2018/Q5_CommunityCollege.mdx
+++ b/src/data/ballot-questions/november-2018/Q5_CommunityCollege.mdx
@@ -37,7 +37,7 @@ Approving this question would allow the state to borrow $15 million to upgrade f
 
 If this question is approved, it will allow the state to borrow up to $15 million to upgrade laboratories, information technology, and facilities at all Maine’s community colleges.[^1]
 
-This is a **bond issue** -- if voters approve the bond, it means that the State of Maine is allowed to borrow money for the project described in the ballot question and has to pay it back over 10 years.[^3] [Learn more about how bonds work](/bonds).
+This is a **bond issue** -- if voters approve the bond, it means that the State of Maine is allowed to borrow money for the project described in the ballot question and has to pay it back over 10 years.[^3] [Learn more about how bonds work](/bonds/).
 
 ## Follow the money
 

--- a/src/data/ballot-questions/november-2019/Q1_Transportation.mdx
+++ b/src/data/ballot-questions/november-2019/Q1_Transportation.mdx
@@ -41,7 +41,7 @@ Passing this question would allow the state to borrow $105 million, matched by $
 
 Passing this question would allow the State of Maine to borrow $105 million for a variety of infrastructure improvements, including roads, bridges, railroads, airports, transit and ports.[^3] The bulk of the money will go towards high priority highways and bridges. See the Ballotpedia Article[^2] for definitions of road priority levels.
 
-This is a **bond issue** -- if voters approve the bond, it means that the State of Maine is allowed to borrow money for the project described in the ballot question and has to pay it back over 10 years. [Learn more about how bonds work](/bonds).
+This is a **bond issue** -- if voters approve the bond, it means that the State of Maine is allowed to borrow money for the project described in the ballot question and has to pay it back over 10 years. [Learn more about how bonds work](/bonds/).
 
 ## Follow the money
 

--- a/src/data/ballot-questions/november-2021/Q2_Transportation.mdx
+++ b/src/data/ballot-questions/november-2021/Q2_Transportation.mdx
@@ -37,7 +37,7 @@ Passing this question would allow the state to borrow $100 million, matched by $
 
 Passing this question would allow the State of Maine to borrow $100 million for a variety of infrastructure improvements, including roads, bridges, railroads, airports, transit and ports.[^2] The bulk of the money will go towards high priority highways and bridges.
 
-This is a **bond issue** -- if voters approve the bond, it means that the State of Maine is allowed to borrow money for the project described in the ballot question and has to pay it back over 10 years. [Learn more about how bonds work](/bonds).
+This is a **bond issue** -- if voters approve the bond, it means that the State of Maine is allowed to borrow money for the project described in the ballot question and has to pay it back over 10 years. [Learn more about how bonds work](/bonds/).
 
 ## Follow the money
 

--- a/src/data/ballot-questions/november-2023/Q1_QuasiBorrowing.mdx
+++ b/src/data/ballot-questions/november-2023/Q1_QuasiBorrowing.mdx
@@ -25,7 +25,7 @@ lastModifiedDate: "2023-10-07"
 
 ## The gist
 
-This citizen's initiative would require voter approval for spending over $1 billion by certain government-controlled entities and utilities. The initiative was started in response to the bills to create a consumer-owned utility (see [Question 3](/ballot-question/november-2023/q3_pinetreepower)).
+This citizen's initiative would require voter approval for spending over $1 billion by certain government-controlled entities and utilities. The initiative was started in response to the bills to create a consumer-owned utility (see [Question 3](/ballot-question/november-2023/q3_pinetreepower/)).
 
 ## Ballot question
 

--- a/src/data/ballot-questions/november-2023/Q1_QuasiBorrowing.mdx
+++ b/src/data/ballot-questions/november-2023/Q1_QuasiBorrowing.mdx
@@ -25,7 +25,7 @@ lastModifiedDate: "2023-10-07"
 
 ## The gist
 
-This citizen's initiative would require voter approval for spending over $1 billion by certain government-controlled entities and utilities. The initiative was started in response to the bills to create a consumer-owned utility (see [Question 3](../q3_pinetreepower/)).
+This citizen's initiative would require voter approval for spending over $1 billion by certain government-controlled entities and utilities. The initiative was started in response to the bills to create a consumer-owned utility (see [Question 3](/ballot-question/november-2023/q3_pinetreepower)).
 
 ## Ballot question
 

--- a/src/data/ballot-questions/november-2023/Q3_PineTreePower.mdx
+++ b/src/data/ballot-questions/november-2023/Q3_PineTreePower.mdx
@@ -24,7 +24,7 @@ lastModifiedDate: "2023-08-13"
 
 This citizen initiative would require the investor-owned utilities, mainly Central Maine Power and Versant Power, to sell their distribution and transmission facilities to a new consumer-owned company. The consumer-owned company would be known as the Pine Tree Power Company and would be managed by an executive board composed of 7 elected representatives and 6 expert members.
 
-An additional related ballot question, [Question 1](/ballot-question/november-2023/q1_quasiborrowing), could add a layer of complexity to a successful Yes vote by requiring future ballot questions for any issuance of debt that is more than $1 billion. You may want to consider your choices for both questions together.
+An additional related ballot question, [Question 1](/ballot-question/november-2023/q1_quasiborrowing/), could add a layer of complexity to a successful Yes vote by requiring future ballot questions for any issuance of debt that is more than $1 billion. You may want to consider your choices for both questions together.
 
 ## Ballot question
 

--- a/src/data/ballot-questions/november-2023/Q3_PineTreePower.mdx
+++ b/src/data/ballot-questions/november-2023/Q3_PineTreePower.mdx
@@ -24,7 +24,7 @@ lastModifiedDate: "2023-08-13"
 
 This citizen initiative would require the investor-owned utilities, mainly Central Maine Power and Versant Power, to sell their distribution and transmission facilities to a new consumer-owned company. The consumer-owned company would be known as the Pine Tree Power Company and would be managed by an executive board composed of 7 elected representatives and 6 expert members.
 
-An additional related ballot question, [Question 1](../q1_quasiborrowing/), could add a layer of complexity to a successful Yes vote by requiring future ballot questions for any issuance of debt that is more than $1 billion. You may want to consider your choices for both questions together.
+An additional related ballot question, [Question 1](/ballot-question/november-2023/q1_quasiborrowing), could add a layer of complexity to a successful Yes vote by requiring future ballot questions for any issuance of debt that is more than $1 billion. You may want to consider your choices for both questions together.
 
 ## Ballot question
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -39,7 +39,7 @@ import dayjs from 'dayjs'
       </p>
       <ul>
         <li>
-          <a href="/contributors">Contributors</a>
+          <a href="/contributors/">Contributors</a>
         </li>
         <li>
           <a href="https://goo.gl/forms/FOoMTZQJvsKE13pB2">Sign up to participate in user research</a>

--- a/src/pages/ballot-question/[...slug].astro
+++ b/src/pages/ballot-question/[...slug].astro
@@ -86,7 +86,7 @@ const { Content } = await render(ballotMeasure)
                 <li>
                   <a
                     class="flex rounded h-9 px-3 items-center border no-underline text-neutral-600 border-neutral-400 hover:text-[#235e70]"
-                    href={`/tags#${tag.id}`}
+                    href={`/tags/#${tag.id}`}
                   >
                     {tag.data.title}
                   </a>
@@ -104,7 +104,7 @@ const { Content } = await render(ballotMeasure)
             <li>
               <a
                 class="flex rounded h-9 px-3 items-center border no-underline text-neutral-600 border-neutral-400 hover:text-[#235e70]"
-                href={`/elections#${election.id}`}>{election.data.title}</a
+                href={`/elections/#${election.id}`}>{election.data.title}</a
               >
             </li>
           </ul>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -65,7 +65,7 @@ const upcomingBallotMeasures = (
   <div class="bg-[#2f6585] mb-12">
     <Container class="text-center py-10">
       <p class="text-xl lg:text-2xl font-bold text-white">
-        More about how to <a href="/vote" class="underline text-[#EAE6D2]">vote in Maine</a>
+        More about how to <a href="/vote/" class="underline text-[#EAE6D2]">vote in Maine</a>
       </p>
     </Container>
   </div>
@@ -117,7 +117,7 @@ const upcomingBallotMeasures = (
     <h3>Local ballot questions</h3>
     <p>We have links to local election websites and ballot drop box locations for counties, cities, and towns.</p>
     <p>
-      <a href="/local">Find information about your local election</a>.
+      <a href="/local/">Find information about your local election</a>.
     </p>
     <hr class="w-1/4 h-1 bg-[#2f6585] mx-auto my-12" />
   </Container>

--- a/src/pages/vote.astro
+++ b/src/pages/vote.astro
@@ -66,7 +66,7 @@ import dayjs from 'dayjs'
       </p>
       <ul>
         <li>
-          <a href="/ballotfill">Tips for completing an absentee ballot</a>
+          <a href="/ballotfill/">Tips for completing an absentee ballot</a>
         </li>
         <li>
           <a href="https://apps.web.maine.gov/cgi-bin/online/AbsenteeBallot/ballot_status.pl"

--- a/src/utils/get-url.ts
+++ b/src/utils/get-url.ts
@@ -5,10 +5,10 @@ export function getEntryUrl(
   entry: CollectionEntry<CollectionKey>,
 ) {
   return match<CollectionEntry<CollectionKey>>(entry)
-    .with({ collection: 'candidates' }, entry => `/candidates-archive/${entry.id}`)
-    .with({ collection: 'ballot-questions' }, entry => `/ballot-question/${entry.id}`)
-    .with({ collection: 'local' }, entry => `/local-archive/${entry.id}`)
-    .with({ collection: 'elections' }, entry => `/elections/${entry.id}`)
-    .with({ collection: 'tags' }, entry => `/tags/${entry.id}`)
+    .with({ collection: 'candidates' }, entry => `/candidates-archive/${entry.id}/`)
+    .with({ collection: 'ballot-questions' }, entry => `/ballot-question/${entry.id}/`)
+    .with({ collection: 'local' }, entry => `/local-archive/${entry.id}/`)
+    .with({ collection: 'elections' }, entry => `/elections/${entry.id}/`)
+    .with({ collection: 'tags' }, entry => `/tags/${entry.id}/`)
     .exhaustive()
 }


### PR DESCRIPTION
Updates internal links to use a trailing slash. Astro doesn't care if you use a trailing slash or not, by default. But the sitemap and canonical links do use a trailing slash by default so by matching the links to the canonicals we can avoid some SEO issues.

We can let Astro be unopinionated (pages will display correctly with or without a trailing slash) to avoid issues with external sites linking to a page on the site