### PR TITLE
Add custom 404

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,16 @@
+---
+import Container from '#components/container.astro'
+import GlobalLayout from '#layouts/global-layout.astro'
+---
+
+<GlobalLayout title="Page not found" description="">
+  <Container class="my-16 text-center">
+    <h1 class="text-3xl md:text-4xl lg:text-5xl font-bold mb-8 text-neutral-700">Page not found</h1>
+    <div class="prose prose-neutral">
+      <p>Sorry, the page you were looking for does not exist or has moved.</p>
+      <p>
+        <a href="/" class="text-[#2f6585] underline">Back to home</a>
+      </p>
+    </div>
+  </Container>
+</GlobalLayout>

--- a/src/pages/[code].astro
+++ b/src/pages/[code].astro
@@ -1,6 +1,13 @@
 ---
 import Container from '#components/container.astro'
 import GlobalLayout from '#layouts/global-layout.astro'
+
+// We should be using a 404.astro for this, but there is an issue with this. Tracking: https://github.com/withastro/adapters/issues/374
+export async function getStaticPaths() {
+  return ['404'].map((post) => ({
+    params: { code: post },
+  }))
+}
 ---
 
 <GlobalLayout title="Page not found" description="">

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,7 +3,8 @@
   "compatibility_date": "2025-09-18",
   "compatibility_flags": ["nodejs_compat"],
   "assets": {
-    "directory": "./dist"
+    "directory": "./dist",
+    "not_found_handling": "404-page"
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
Adds a custom 404 page.

Cloudflare doesn't automatically show a 404 page like netlify, so this adds one.

<img width="1324" alt="image" src="https://github.com/user-attachments/assets/626e984a-1039-473a-89ac-9180573be7f3">
